### PR TITLE
Prevent white page if no target is defined (e.g. Sprengstoff)

### DIFF
--- a/src/views/DetailPage.vue
+++ b/src/views/DetailPage.vue
@@ -80,10 +80,17 @@ export default {
       return this.material ? this.material.notes : 'Loading...'
     },
     share () {
-      return {
-        title: `Mülli: ${this.material?.name} entsorgen 👉 ${this.material?.targets[0].name}`,
-        text: `${this.material?.name} entsorgen: ${this.material?.targets[0].name}
-        ${this.material?.notes}`
+      if (this.material?.targets) {
+        return {
+          title: `Mülli: ${this.material.name} entsorgen 👉 ${this.material.targets[0].name}`,
+          text: `${this.material.name} entsorgen: ${this.material.targets[0].name}
+          ${this.material?.notes}`
+        }
+      } else {
+        return {
+          title: `Mülli: ${this.material?.name} entsorgen`,
+          text: `${this.material?.name} entsorgen: ${this.material?.notes}`
+        }
       }
     }
   },


### PR DESCRIPTION
Prevent white page on showing DetailPage for "Sprengstoff" (having no associated Material)